### PR TITLE
Fix bug in proxy code

### DIFF
--- a/src/leiningen/embongo.clj
+++ b/src/leiningen/embongo.clj
@@ -16,7 +16,7 @@
     (ProxySelector/setDefault (proxy [ProxySelector] []
                                 (select [uri]
                                   (if (= (.getHost uri) "fastdl.mongodb.org")
-                                    (list (Proxy. Proxy$Type/HTTP (.InetSocketAddress proxy-host proxy-port)))
+                                    (list (Proxy. Proxy$Type/HTTP (InetSocketAddress. proxy-host proxy-port)))
                                     (.select default-selector uri)))
                                 (connectFailed [uri address ex] ())))))
 


### PR DESCRIPTION
When `:download_proxy_host` is set in the config, lein-embongo fails, with a stack trace
```
SEVERE: Build ArtifactStore(useCache:true)
Download GenericVersion{2.6.4}:Linux:B64 START
java.lang.IllegalArgumentException: No matching method found: InetSocketAddress for class java.lang.String
 at clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:53)
    clojure.lang.Reflector.invokeInstanceMethod (Reflector.java:28)
    leiningen.embongo$add_proxy_selector_BANG_$fn__8039.invoke (embongo.clj:19)
    leiningen.embongo.proxy$java.net.ProxySelector$ff19274a.select (:-1)
    sun.net.www.protocol.http.HttpURLConnection.plainConnect0 (HttpURLConnection.java:1097)
    sun.net.www.protocol.http.HttpURLConnection.plainConnect (HttpURLConnection.java:997)
    sun.net.www.protocol.http.HttpURLConnection.connect (HttpURLConnection.java:931)
    sun.net.www.protocol.http.HttpURLConnection.getInputStream0 (HttpURLConnection.java:1511)
    sun.net.www.protocol.http.HttpURLConnection.getInputStream (HttpURLConnection.java:1439)
    de.flapdoodle.embed.process.store.Downloader.download (Downloader.java:74)
    de.flapdoodle.embed.process.store.ArtifactStore.checkDistribution (ArtifactStore.java:53)
    de.flapdoodle.embed.process.store.CachingArtifactStore.checkDistribution (CachingArtifactStore.java:54)
    de.flapdoodle.embed.process.runtime.Starter.prepare (Starter.java:55)
    leiningen.embongo$start_mongo.invoke (embongo.clj:47)
    leiningen.embongo$embongo.doInvoke (embongo.clj:62)
````
The bug is caused by trying to call InetSocketAddress as a method on String, rather than instantiating it.