### PR TITLE
update de.flapdoodle.embed.mongo to 2.0.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/joelittlejohn/lein-embongo"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[de.flapdoodle.embed/de.flapdoodle.embed.mongo "1.46.4"]]
+  :dependencies [[de.flapdoodle.embed/de.flapdoodle.embed.mongo "2.0.0"]]
   :eval-in-leiningen true
   :repositories [["releases" {:url "https://clojars.org/repo"
                               :creds :gpg}]]


### PR DESCRIPTION
I have tested lein-embongo with the new version of de.flapdoodle.embed.mongo. The new version fixes a bug that some exception is thrown when shutting down mongodb.