### PR TITLE
Fix a bug that the download of the version 3.6+ is not working, update embongo to 2.1.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/joelittlejohn/lein-embongo"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[de.flapdoodle.embed/de.flapdoodle.embed.mongo "2.0.0"]]
+  :dependencies [[de.flapdoodle.embed/de.flapdoodle.embed.mongo "2.1.1"]]
   :eval-in-leiningen true
   :repositories [["releases" {:url "https://clojars.org/repo"
                               :creds :gpg}]]

--- a/src/leiningen/embongo.clj
+++ b/src/leiningen/embongo.clj
@@ -4,9 +4,9 @@
             [leiningen.core.main :as main])
   (:import [de.flapdoodle.embed.mongo Command MongodStarter]
            [de.flapdoodle.embed.mongo.config RuntimeConfigBuilder MongodConfigBuilder Net Storage]
-           [de.flapdoodle.embed.mongo.distribution Feature Version Versions]
+           [de.flapdoodle.embed.mongo.distribution Feature Version Versions Version$Main]
            [de.flapdoodle.embed.process.config.io ProcessOutput]
-           [de.flapdoodle.embed.process.distribution IVersion]
+           [de.flapdoodle.embed.process.distribution IVersion GenericVersion]
            [de.flapdoodle.embed.process.io IStreamProcessor NamedOutputStreamProcessor]
            [de.flapdoodle.embed.process.runtime Network]
            [java.net InetSocketAddress Proxy Proxy$Type ProxySelector]))
@@ -43,7 +43,7 @@
 
 (defn- parse-version [v]
   (try
-    (Version/valueOf v)
+    (Versions/withFeatures (new GenericVersion v) (.getFeatures Version$Main/PRODUCTION))
     (catch IllegalArgumentException e
       (Versions/withFeatures (reify IVersion (asInDownloadPath [_] v)) (make-array Feature 0)))))
 


### PR DESCRIPTION
+ Update embongo to 2.1.1
+ Fix a bug that the download of the version 3.6+ is not working (see the [issue](https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/256#issuecomment-407474716))  